### PR TITLE
fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export interface ResizeOptions {
   maxWidth?: number;
   quality?: number;
   type?: string;
+  bgColor?: string;
 }
 
 export interface Options {
@@ -106,12 +107,15 @@ export interface Options {
  - `resize.quality`: default: `0.7`
  - `resize.type`: default: as the original image
  - `allowedExtensions`: default: undefined
+ - `bgColor`: default: undefined
 
 Resize algorithm ensures, that the resized image can fit into the specified `resize.maxHeight x resize.maxWidth` size.
 
 Allowed extensions array (e.g. `['jpg', 'jpeg', 'png']`; case insensitive): if specified and an input file
 has different extension the `(imageSelected)` event is fired with the error field set to 'Extension Not Allowed'.
 `dataURL` and `resize` not calculated at all.
+
+`bgColor` is an optional parameter to force a certain color when 'flattening' transparent images, as the default background color is black and this may be undesirable).
 
 ## Multi-Injector `IMAGE_FILE_PROCESSOR` as `ImageFileProcessor`
 

--- a/projects/ngx-image2dataurl/src/lib/interfaces.ts
+++ b/projects/ngx-image2dataurl/src/lib/interfaces.ts
@@ -14,7 +14,7 @@ export interface ResizeOptions {
   maxWidth?: number;
   quality?: number;
   type?: string;
-  flattenTransparencyToWhite?: boolean;
+  bgColor?: string;
 }
 
 export interface Options {

--- a/projects/ngx-image2dataurl/src/lib/interfaces.ts
+++ b/projects/ngx-image2dataurl/src/lib/interfaces.ts
@@ -14,6 +14,7 @@ export interface ResizeOptions {
   maxWidth?: number;
   quality?: number;
   type?: string;
+  flattenTransparencyToWhite?: boolean;
 }
 
 export interface Options {

--- a/projects/ngx-image2dataurl/src/lib/utils.ts
+++ b/projects/ngx-image2dataurl/src/lib/utils.ts
@@ -10,6 +10,7 @@ export function createImageFromDataUrl(dataURL: string) {
 }
 
 export async function resizeImage(dataURL: string, {
+  flattenTransparencyToWhite,
   maxHeight,
   maxWidth,
   quality = 0.7,
@@ -40,7 +41,7 @@ export async function resizeImage(dataURL: string, {
   //draw image on canvas
   const ctx = canvas.getContext("2d");
   
-  if(type !== 'image/png'){
+  if(flattenTransparencyToWhite){
     ctx.fillStyle = 'white';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
   }

--- a/projects/ngx-image2dataurl/src/lib/utils.ts
+++ b/projects/ngx-image2dataurl/src/lib/utils.ts
@@ -10,7 +10,7 @@ export function createImageFromDataUrl(dataURL: string) {
 }
 
 export async function resizeImage(dataURL: string, {
-  flattenTransparencyToWhite,
+  bgColor,
   maxHeight,
   maxWidth,
   quality = 0.7,
@@ -41,8 +41,8 @@ export async function resizeImage(dataURL: string, {
   //draw image on canvas
   const ctx = canvas.getContext("2d");
   
-  if(flattenTransparencyToWhite){
-    ctx.fillStyle = 'white';
+  if(bgColor){
+    ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
   }
   

--- a/projects/ngx-image2dataurl/src/lib/utils.ts
+++ b/projects/ngx-image2dataurl/src/lib/utils.ts
@@ -39,8 +39,12 @@ export async function resizeImage(dataURL: string, {
 
   //draw image on canvas
   const ctx = canvas.getContext("2d");
-  ctx.fillStyle = 'white';
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  
+  if(type !== 'image/png'){
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  
   ctx.drawImage(image, 0, 0, width, height);
 
   // get the data from canvas as 70% jpg (or specified type).

--- a/projects/ngx-image2dataurl/src/lib/utils.ts
+++ b/projects/ngx-image2dataurl/src/lib/utils.ts
@@ -39,6 +39,8 @@ export async function resizeImage(dataURL: string, {
 
   //draw image on canvas
   const ctx = canvas.getContext("2d");
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.drawImage(image, 0, 0, width, height);
 
   // get the data from canvas as 70% jpg (or specified type).


### PR DESCRIPTION
@ribizli this is the true fix, it sets a white background so transparent images that are forced to be drawn as JPEG can at least have a white background which 99% of the time is desired. pls merge and release